### PR TITLE
fix fake sync vars

### DIFF
--- a/Extensions/FakeSyncCoreExtension.cs
+++ b/Extensions/FakeSyncCoreExtension.cs
@@ -11,8 +11,7 @@ internal static class FakeSyncCoreExtension
 
         using NetworkWriterPooled writer = NetworkWriterPool.Get();
         
-        // We're changing the First NetworkBehaviour of the NetId!
-        // Some prefabs have multiple NetworkBehaviour, in that case you are on your own :(
+        // gets the dirty mask based on the changed behavior's index
         NetworkBehaviour[] behaviors = networkBehaviour.netIdentity.NetworkBehaviours;
         int index = behaviors == null ? 0 : Array.IndexOf(behaviors, networkBehaviour);
         Compression.CompressVarUInt(writer, 1UL << index);

--- a/Extensions/FakeSyncCoreExtension.cs
+++ b/Extensions/FakeSyncCoreExtension.cs
@@ -4,16 +4,10 @@ namespace LabApiExtensions.Extensions;
 
 internal static class FakeSyncCoreExtension
 {
-    internal static void SendFakeCore(this Player target, NetworkBehaviour networkBehaviour, Action<NetworkWriterPooled>? writeSyncData = null, Action<NetworkWriterPooled>? writeSyncVar = null)
+    internal static void SendFakeCore(this Player target, NetworkBehaviour networkBehaviour, Action<NetworkWriterPooled> writeSyncData, Action<NetworkWriterPooled> writeSyncVar)
     {
         if (target.Connection == null)
             return;
-
-        if (writeSyncData == null || writeSyncVar == null)
-        {
-            CL.Error("You have not made a SyncData or a SyncVar writer!");
-            return;
-        }
 
         using NetworkWriterPooled writer = NetworkWriterPool.Get();
         

--- a/Extensions/FakeSyncCoreExtension.cs
+++ b/Extensions/FakeSyncCoreExtension.cs
@@ -15,13 +15,13 @@ internal static class FakeSyncCoreExtension
             return;
         }
 
-        Type networkType = networkBehaviour.GetType();
-
-        NetworkWriterPooled writer = NetworkWriterPool.Get();
-
-        // We changing the First NetworkBehaviour of the NetId!
+        using NetworkWriterPooled writer = NetworkWriterPool.Get();
+        
+        // We're changing the First NetworkBehaviour of the NetId!
         // Some prefabs have multiple NetworkBehaviour, in that case you are on your own :(
-        Compression.CompressVarUInt(writer, 1);
+        NetworkBehaviour[] behaviors = networkBehaviour.netIdentity.NetworkBehaviours;
+        int index = behaviors == null ? 0 : Array.IndexOf(behaviors, networkBehaviour);
+        Compression.CompressVarUInt(writer, 1UL << index);
 
         // placeholder length
         int headerPosition = writer.Position;
@@ -29,10 +29,10 @@ internal static class FakeSyncCoreExtension
         int contentPosition = writer.Position;
 
         // Serialize Object Sync Data.
-        writeSyncData?.Invoke(writer);
+        writeSyncData.Invoke(writer);
 
         // Write Object Sync Vars
-        writeSyncVar?.Invoke(writer);
+        writeSyncVar.Invoke(writer);
 
         // end position safety write
         int endPosition = writer.Position;

--- a/Extensions/FakeSyncListExtension.cs
+++ b/Extensions/FakeSyncListExtension.cs
@@ -12,36 +12,36 @@ public static class FakeSyncListExtension
         public ListOperation operation;
     }
 
-    public static void SendFakeSyncListAdd<T>(this Player target, NetworkBehaviour networkBehaviour, ulong ListIndex, T value)
-        => SendFakeSyncList<T>(target, networkBehaviour, ListIndex, new()
+    public static void SendFakeSyncListAdd<T>(this Player target, NetworkBehaviour networkBehaviour, ulong listIndex, T value)
+        => SendFakeSyncList<T>(target, networkBehaviour, listIndex, new()
         {
             operation = ListOperation.Add,
             value = value
         });
 
-    public static void SendFakeSyncListClear<T>(this Player target, NetworkBehaviour networkBehaviour, ulong ListIndex)
-        => SendFakeSyncList<T>(target, networkBehaviour, ListIndex, new()
+    public static void SendFakeSyncListClear<T>(this Player target, NetworkBehaviour networkBehaviour, ulong listIndex)
+        => SendFakeSyncList<T>(target, networkBehaviour, listIndex, new()
         {
             operation = ListOperation.Clear,
         });
 
-    public static void SendFakeSyncListRemoveAt<T>(this Player target, NetworkBehaviour networkBehaviour, ulong ListIndex, int index)
-        => SendFakeSyncList<T>(target, networkBehaviour, ListIndex, new()
+    public static void SendFakeSyncListRemoveAt<T>(this Player target, NetworkBehaviour networkBehaviour, ulong listIndex, int index)
+        => SendFakeSyncList<T>(target, networkBehaviour, listIndex, new()
         {
             operation = ListOperation.RemoveAt,
             index = index
         });
 
-    public static void SendFakeSyncListInsert<T>(this Player target, NetworkBehaviour networkBehaviour, ulong ListIndex, int index, T value)
-        => SendFakeSyncList<T>(target, networkBehaviour, ListIndex, new()
+    public static void SendFakeSyncListInsert<T>(this Player target, NetworkBehaviour networkBehaviour, ulong listIndex, int index, T value)
+        => SendFakeSyncList<T>(target, networkBehaviour, listIndex, new()
         {
             operation = ListOperation.Insert,
             index = index,
             value = value
         });
 
-    public static void SendFakeSyncListSet<T>(this Player target, NetworkBehaviour networkBehaviour, ulong ListIndex, int index, T value)
-        => SendFakeSyncList<T>(target, networkBehaviour, ListIndex, new()
+    public static void SendFakeSyncListSet<T>(this Player target, NetworkBehaviour networkBehaviour, ulong listIndex, int index, T value)
+        => SendFakeSyncList<T>(target, networkBehaviour, listIndex, new()
         {
             operation = ListOperation.Set,
             index = index,
@@ -49,13 +49,13 @@ public static class FakeSyncListExtension
         });
 
 
-    public static void SendFakeSyncList<T>(this Player target, NetworkBehaviour networkBehaviour, ulong ListIndex, ListChanger<T> changer)
+    public static void SendFakeSyncList<T>(this Player target, NetworkBehaviour networkBehaviour, ulong listIndex, ListChanger<T> changer)
     {
         target.SendFakeCore(networkBehaviour,
         (writer) => 
         {
             // Serialize Object Sync Data.
-            writer.WriteULong(ListIndex);
+            writer.WriteULong(listIndex);
 
             // Copy from OnSerializeDelta
             writer.WriteUInt(1);

--- a/Extensions/FakeSyncVarExtension.cs
+++ b/Extensions/FakeSyncVarExtension.cs
@@ -7,43 +7,46 @@ public static class FakeSyncVarExtension
 {
     private static readonly Dictionary<Type, ulong> SubWriteClassToMinULong = new()
     {
-        [typeof(AdminToyBase)] = 16,
+        [typeof(AdminToyBase)] = 32,
     };
+
+    private static ulong GetSubclassMinDirtyBit(Type type)
+    {
+        foreach (KeyValuePair<Type, ulong> kvp in SubWriteClassToMinULong)
+        {
+            if (type.IsSubclassOf(kvp.Key))
+                return kvp.Value;
+        }
+
+        return ulong.MaxValue;
+    }
 
     // Easier syncVar
     public static void SendFakeSyncVar<T>(this Player target, NetworkBehaviour networkBehaviour, ulong dirtyBit, T syncVar)
     {
         Type networkType = networkBehaviour.GetType();
 
-        target.SendFakeCore(networkBehaviour, 
+        target.SendFakeCore(networkBehaviour,
         (writer) => writer.WriteULong(0), // Write No SyncData
-        (writer) =>  // Write SyncVar
+        (writer) => // Write SyncVar
         {
             // Write DrityBit always
             writer.WriteULong(dirtyBit);
 
-            bool IsWritten = false;
+            ulong minDirtyBit = GetSubclassMinDirtyBit(networkType);
+            bool isWritten = false;
 
-            foreach (KeyValuePair<Type, ulong> kv in SubWriteClassToMinULong)
+            if (dirtyBit >= minDirtyBit)
             {
-                if (networkType.IsSubclassOf(kv.Key))
-                {
-                    if (kv.Value >= dirtyBit)
-                        writer.Write(syncVar);
-
-                    // Write always
-                    writer.WriteULong(dirtyBit);
-
-                    if (kv.Value <= dirtyBit)
-                        writer.Write(syncVar);
-
-                    IsWritten = true;
-                }
+                writer.WriteULong(dirtyBit);
+                isWritten = true;
             }
 
-            if (!IsWritten)
-                // we can just write normally
-                writer.Write(syncVar);
+            writer.Write(syncVar);
+
+            if (!isWritten)
+                writer.WriteULong(dirtyBit);
+
         });
     }
 
@@ -57,7 +60,7 @@ public static class FakeSyncVarExtension
 
         target.SendFakeCore(networkBehaviour,
         (writer) => writer.WriteULong(0), // Write No SyncData
-        (writer) =>  // Write SyncVar
+        (writer) => // Write SyncVar
         {
             ulong dirtyBit = 0;
             foreach (ulong dirty in syncVars.Select(x => x.DirtyBit).ToArray())


### PR DESCRIPTION
- Fixed and cleaned up the SendFakeSyncVar<T> method
- Simplified and fixed the SendFakeSyncVars method
- Fixed inconsistent naming in the arguments of FakeSyncListExtension